### PR TITLE
Dispatch actions received from remote devtools

### DIFF
--- a/example/githubsearch/lib/main.dart
+++ b/example/githubsearch/lib/main.dart
@@ -23,6 +23,8 @@ void main() async {
 
   remoteDevtools.store = store;
 
+  remoteDevtools.connect();
+
   runApp(new RxDartGithubSearchApp(
     store: store,
   ));

--- a/lib/redux_remote_devtools.dart
+++ b/lib/redux_remote_devtools.dart
@@ -6,7 +6,8 @@ import 'package:redux_dev_tools/redux_dev_tools.dart';
 import 'dart:convert';
 import 'dart:async';
 
+part './src/action_decoder.dart';
 part './src/action_encoder.dart';
+part './src/remote_devtools_middleware.dart';
 part './src/socketcluster_wrapper.dart';
 part './src/state_encoder.dart';
-part './src/remote_devtools_middleware.dart';

--- a/lib/src/action_decoder.dart
+++ b/lib/src/action_decoder.dart
@@ -1,0 +1,18 @@
+part of redux_remote_devtools;
+
+/// Interface for custom remote action decoding logic
+abstract class ActionDecoder {
+  const ActionDecoder();
+
+  // Converts a JSON payload from remote devtools to an action
+  dynamic decode(dynamic json);
+}
+
+/// An action decoder that simply passes through the JSON unmodified
+class NOPActionDecoder extends ActionDecoder {
+  const NOPActionDecoder() : super();
+
+  dynamic decode(dynamic action) {
+    return action;
+  }
+}

--- a/lib/src/action_decoder.dart
+++ b/lib/src/action_decoder.dart
@@ -9,8 +9,8 @@ abstract class ActionDecoder {
 }
 
 /// An action decoder that simply passes through the JSON unmodified
-class NOPActionDecoder extends ActionDecoder {
-  const NOPActionDecoder() : super();
+class NopActionDecoder extends ActionDecoder {
+  const NopActionDecoder() : super();
 
   dynamic decode(dynamic action) {
     return action;

--- a/lib/src/remote_devtools_middleware.dart
+++ b/lib/src/remote_devtools_middleware.dart
@@ -99,6 +99,9 @@ class RemoteDevToolsMiddleware extends MiddlewareClass {
       case 'START':
         _setStatus(RemoteDevToolsStatus.started);
         break;
+      case 'ACTION':
+        _handleRemoteAction(data['action'] as String);
+        break;
       default:
         print('Unknown type:' + data['type'].toString());
     }
@@ -114,8 +117,17 @@ class RemoteDevToolsMiddleware extends MiddlewareClass {
         this.store.dispatch(new DevToolsAction.jumpToState(action['index'] as int));
         break;
       default:
-        this.store.dispatch(new DevToolsAction.perform(this.actionDecoder.decode(action)));
+        print("Unknown commans: ${action['type']}. Ignoring");
     }
+  }
+
+  void _handleRemoteAction(String action) {
+    if (this.store == null) {
+      print('No store reference set, cannot dispatch remote action');
+      return;
+    }
+    var actionMap = jsonDecode(action);
+    this.store.dispatch(new DevToolsAction.perform(this.actionDecoder.decode(actionMap)));
   }
 
   /// Middleware function called by redux, dispatches actions to devtools

--- a/lib/src/remote_devtools_middleware.dart
+++ b/lib/src/remote_devtools_middleware.dart
@@ -36,11 +36,13 @@ class RemoteDevToolsMiddleware extends MiddlewareClass {
   ActionEncoder actionEncoder;
   StateEncoder stateEncoder;
 
-  RemoteDevToolsMiddleware(this._host,
-      {this.actionDecoder = const NOPActionDecoder(),
-      this.actionEncoder = const JsonActionEncoder(),
-      this.stateEncoder = const JsonStateEncoder(),
-      this.socket}) {
+  RemoteDevToolsMiddleware(
+    this._host, {
+    this.actionDecoder = const NopActionDecoder(),
+    this.actionEncoder = const JsonActionEncoder(),
+    this.stateEncoder = const JsonStateEncoder(),
+    this.socket,
+  }) {
     if (socket == null) {
       this.socket = new SocketClusterWrapper('ws://${this._host}/socketcluster/');
     }

--- a/test/action_decoder_test.dart
+++ b/test/action_decoder_test.dart
@@ -6,7 +6,7 @@ void main() {
     group('decode', () {
       test('Passes through the json payload', () {
         var payload = {'type': 'SOME ACTION', 'value': 123};
-        var decoder = new NOPActionDecoder();
+        var decoder = new NopActionDecoder();
         var result = decoder.decode(payload);
         expect(result, payload);
       });

--- a/test/action_decoder_test.dart
+++ b/test/action_decoder_test.dart
@@ -1,0 +1,15 @@
+import 'package:test/test.dart';
+import '../lib/redux_remote_devtools.dart';
+
+void main() {
+  group('NOPActionDecoder', () {
+    group('decode', () {
+      test('Passes through the json payload', () {
+        var payload = {'type': 'SOME ACTION', 'value': 123};
+        var decoder = new NOPActionDecoder();
+        var result = decoder.decode(payload);
+        expect(result, payload);
+      });
+    });
+  });
+}

--- a/test/remote_devtools_middleware_test.dart
+++ b/test/remote_devtools_middleware_test.dart
@@ -169,6 +169,14 @@ void main() {
         devtools.handleEventFromRemote(remoteData);
         verify(store.dispatch(new DevToolsAction.jumpToState(4)));
       });
+      test('Dispatches arbitrary remote actions', () {
+        var remoteData = {
+          'type': 'DISPATCH',
+          'action': {'type': 'TEST ACTION', 'value': 12}
+        };
+        devtools.handleEventFromRemote(remoteData);
+        verify(store.dispatch(new DevToolsAction.perform(remoteData['action'])));
+      });
       test('Does not dispatch if store has not been sent', () {
         devtools.store = null;
         var remoteData = {

--- a/test/remote_devtools_middleware_test.dart
+++ b/test/remote_devtools_middleware_test.dart
@@ -2,6 +2,7 @@ import '../lib/redux_remote_devtools.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'dart:async';
+import 'dart:convert';
 import 'package:redux/redux.dart';
 import 'package:redux_dev_tools/redux_dev_tools.dart';
 
@@ -170,12 +171,15 @@ void main() {
         verify(store.dispatch(new DevToolsAction.jumpToState(4)));
       });
       test('Dispatches arbitrary remote actions', () {
-        var remoteData = {
-          'type': 'DISPATCH',
-          'action': {'type': 'TEST ACTION', 'value': 12}
-        };
+        var remoteData = {'type': 'ACTION', 'action': '{"type": "TEST ACTION", "value": 12}'};
         devtools.handleEventFromRemote(remoteData);
-        verify(store.dispatch(new DevToolsAction.perform(remoteData['action'])));
+        print(jsonDecode(remoteData['action']));
+        var expected = new DevToolsAction.perform(jsonDecode(remoteData['action']));
+        print(expected);
+        var verifyResult = verify(store.dispatch(captureAny)).captured.first;
+        expect(verifyResult.type, DevToolsActionTypes.PerformAction);
+        expect(verifyResult.appAction['type'], 'TEST ACTION');
+        expect(verifyResult.appAction['value'], 12);
       });
       test('Does not dispatch if store has not been sent', () {
         devtools.store = null;

--- a/test/test_all.dart
+++ b/test/test_all.dart
@@ -1,3 +1,4 @@
+import 'action_decoder_test.dart' as actionDecoder;
 import 'action_encoder_test.dart' as actionEncoder;
 import 'socketcluster_wrapper_test.dart' as socketWrapper;
 import 'state_encoder_test.dart' as stateEncoder;
@@ -6,6 +7,7 @@ import 'remote_devtools_middleware_test.dart' as devtools;
 /// Script for running all tests on Travis CI
 /// Allows us to generate code coverage
 void main() {
+  actionDecoder.main();
   actionEncoder.main();
   stateEncoder.main();
   devtools.main();


### PR DESCRIPTION
* Adds a new ActionDecoder class, that is responsible for converting
JSON objects from remote devtools into action objects suitable for your
reducers

* Provides a simple NOP/Passthrough decoder that simply lets the JSON
payload through

* Allows app developers to create their own ActionDecoders that know how
to decode actions they are interested in

Closes #7 