### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/example/githubsearch/lib/github_search_api.dart
+++ b/example/githubsearch/lib/github_search_api.dart
@@ -33,7 +33,8 @@ class GithubApi {
   Future<SearchResult> _fetchResults(String term) async {
     final request = await new HttpClient().getUrl(Uri.parse("$baseUrl$term"));
     final response = await request.close();
-    final results = json.decode(await response.transform(utf8.decoder).join());
+    final results = json.decode(
+        await response.cast<List<int>>().transform(utf8.decoder).join());
 
     return new SearchResult.fromJson(results['items']);
   }


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900