### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/example/githubsearch/lib/github_search_api.dart
+++ b/example/githubsearch/lib/github_search_api.dart
@@ -33,8 +33,7 @@ class GithubApi {
   Future<SearchResult> _fetchResults(String term) async {
     final request = await new HttpClient().getUrl(Uri.parse("$baseUrl$term"));
     final response = await request.close();
-    final results = json.decode(
-        await response.cast<List<int>>().transform(utf8.decoder).join());
+    final results = json.decode(await utf8.decoder.bind(response).join());
 
     return new SearchResult.fromJson(results['items']);
   }


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
