### PR TITLE
Allow use with Redux 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Redux Remote Devtools
 
+# 1.0.0
+
+- Allows support for Redux 4.0.0 (backwards compatible with 3)
+- Switching to semver versioning
+
 # 0.0.11
 
 - Updates dependency to latest socketcluster_client and makes this package work
@@ -18,7 +23,7 @@
 
 # 0.0.8
 
-- Backwards compatible Update to support changes to Dart API  (thanks @tvolkert)
+- Backwards compatible Update to support changes to Dart API (thanks @tvolkert)
 
 ## 0.0.7
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,9 +2,9 @@ name: redux_remote_devtools
 description: Remote DevTools for Redux.dart
 author: Michael Marner <michael@20papercups.net>
 homepage: https://github.com/MichaelMarner/dart-redux-remote-devtools
-version: 0.0.11
+version: 1.0.0
 dependencies:
-  redux: ^3.0.0
+  redux: '>=3.0.0 <5.0.0'
   redux_dev_tools: ^0.4.0
   socketcluster_client: ^0.2.0
 dev_dependencies:


### PR DESCRIPTION
* Switching to semantic versioning for future releases, hence the 1.0.0