### PR TITLE
Return dispatcher return values

### DIFF
--- a/lib/src/remote_devtools_middleware.dart
+++ b/lib/src/remote_devtools_middleware.dart
@@ -150,12 +150,14 @@ class RemoteDevToolsMiddleware extends MiddlewareClass {
   }
 
   /// Middleware function called by redux, dispatches actions to devtools
-  call(Store store, dynamic action, NextDispatcher next) {
-    next(action);
+  dynamic call(Store store, dynamic action, NextDispatcher next) {
+    final result = next(action);
     if (this.status == RemoteDevToolsStatus.started &&
         !(action is DevToolsAction)) {
       this._relay('ACTION', store.state, action);
     }
+
+    return result;
   }
 
   _setStatus(RemoteDevToolsStatus value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/MichaelMarner/dart-redux-remote-devtools
 version: 1.0.1
 dependencies:
   redux: '>=3.0.0 <5.0.0'
-  redux_dev_tools: '>=0.4.0 <1.0.0'
+  redux_dev_tools: '>=0.5.2 <1.0.0'
   socketcluster_client: ^0.2.0
 dev_dependencies:
   test: ^1.3.0


### PR DESCRIPTION
Hey,

unfortunately [redux_thunk](https://github.com/brianegan/redux_thunk) actions are not working as with the normal redux store. With the `DevToolsStore` I'm not able to write code that awaits the result of a thunk action:
```dart
await store.dispatch(MyThunkAction());
```
I have already [created a PR](https://github.com/brianegan/redux_dev_tools/pull/4) for the upstream [redux_dev_tools](https://github.com/brianegan/redux_dev_tools) package.

However there needs to be a tiny change in this package as well.

I managed to get it working locally when all changes from both repositories are applied.

As soon as the upstream changes are merged I'll update the `pubspec.yml` of this package as well and change remove the "Draft" status of this PR.

EDIT: Now I'm wondering if this change here is only necessary because the `RemoteDevToolsMiddleware` is the first middleware in my chain. The second one is already the `thunkmiddleware`... 🤔 