### PR TITLE
Replace abstract classes with function typdefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,31 @@
-# Redux Remote Devtools
+# 2.0.0
+
+## Breaking Change
+
+Replaces the abstract classes `StateEncoder`, `ActionEncoder`, and `ActionDecoder` with function typedefs.
+This is inline with the [Dart styleguide](http://dart-lang.github.io/linter/lints/one_member_abstracts.html), which advocates using function typedefs instead of single method abstract classes.
+
+**This will only affect you if you are using custom encoders/decoders. No changes if you are using remote devtools as-is.**
+
+Before:
+
+```dart
+class MyActionEncoder extends ActionEncoder {
+  String encode(dynamic action) {
+    // custom encoding logic here...
+  }
+}
+```
+
+After:
+
+```dart
+ActionEncoder MyActionEncoder = (dynamic action) {
+  // custom encoding logic here
+}
+```
+
+Again, for most people this will require no changes to code.
 
 # 1.0.4
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the library to pubspec.yaml:
 
 ```yaml
 dependencies:
-  redux_remote_devtools: ^1.0.4
+  redux_remote_devtools: ^2.0.0
 ```
 
 ## Middleware configuration
@@ -107,10 +107,10 @@ For state, we simply attempt to `jsonEncode` the entire thing. If your state can
 
 ### Overriding these strategies
 
-The strategy described above should work for most cases. However, if you want to do something different, you can replace the `ActionEncoder` and `StateEncoder` with your own classes:
+The strategy described above should work for most cases. However, if you want to do something different, you can replace the `ActionEncoder` and `StateEncoder` with your own implementations:
 
 ```dart
-  var remoteDevtools = RemoteDevToolsMiddleware('192.168.1.52:8000', actionEncoder: new MyCoolActionEncoder());
+  var remoteDevtools = RemoteDevToolsMiddleware('192.168.1.52:8000', actionEncoder: MyCoolActionEncoder);
 ```
 
 ## Making your actions and state json encodable
@@ -132,14 +132,12 @@ In order for this to work, you need to implement an `ActionDecoder`. ActionDecod
 We would implement an ActionDecoder like so:
 
 ```dart
-class MyDecoder extends ActionDecoder {
-  dynamic decode(dynamic payload) {
-    final map = payload as Map<String, dynamic>;
-    if (map['type'] == 'INCREMENT') {
-      return IncrementAction();
-    }
+ActionDecoder myDecoder = (dynamic payload) {
+  final map = payload as Map<String, dynamic>;
+  if (map['type'] == 'INCREMENT') {
+    return IncrementAction();
   }
-}
+};
 ```
 
 Essentially, you need to map every JSON action type into an action that can be used by your reducers.

--- a/lib/src/action_decoder.dart
+++ b/lib/src/action_decoder.dart
@@ -1,19 +1,8 @@
 part of redux_remote_devtools;
 
-/// Interface for custom remote action decoding logic
-abstract class ActionDecoder {
-  const ActionDecoder();
-
-  // Converts a JSON payload from remote devtools to an action
-  dynamic decode(dynamic json);
-}
+/// Interface for custom remote action decoding logic.
+/// Converts a JSON payload from remote devtools to an action
+typedef ActionDecoder = dynamic Function(dynamic json);
 
 /// An action decoder that simply passes through the JSON unmodified
-class NopActionDecoder extends ActionDecoder {
-  const NopActionDecoder() : super();
-
-  @override
-  dynamic decode(dynamic action) {
-    return action;
-  }
-}
+ActionDecoder NopActionDecoder = (dynamic action) => action;

--- a/lib/src/action_encoder.dart
+++ b/lib/src/action_encoder.dart
@@ -5,6 +5,19 @@ part of redux_remote_devtools;
 typedef ActionEncoder = String Function(dynamic action);
 
 /// An action encoder that converts an action to stringified JSON
+///
+/// Encodes an action as stringified JSON
+///
+/// Uses the form:
+///
+/// {
+///   "type": "TYPE"
+///   "payload": jsonEncode(action)
+/// }
+///
+/// Action type is set to be the class name for class based
+/// actions, or an enum value for enum actions
+///
 ActionEncoder JsonActionEncoder = (dynamic action) {
   /// Gets a type name for the action, based on the class name or value
   String getActionType(dynamic action) {

--- a/lib/src/action_encoder.dart
+++ b/lib/src/action_encoder.dart
@@ -1,37 +1,11 @@
 part of redux_remote_devtools;
 
-/// Interface for custom action encoding logic
-abstract class ActionEncoder {
-  const ActionEncoder();
-
-  // Converts an action into a string suitable for sending to devtools
-  String encode(dynamic action);
-}
+/// Interface for custom action encoding logic.
+/// Converts an action into a string suitable for sending to devtools
+typedef ActionEncoder = String Function(dynamic action);
 
 /// An action encoder that converts an action to stringified JSON
-class JsonActionEncoder extends ActionEncoder {
-  const JsonActionEncoder() : super();
-
-  /// Encodes an action as stringified JSON
-  ///
-  /// Uses the form:
-  ///
-  /// {
-  ///   "type": "TYPE"
-  ///   "payload": jsonEncode(action)
-  /// }
-  ///
-  /// Action type is set to be the class name for class based
-  /// actions, or an enum value for enum actions
-  @override
-  String encode(dynamic action) {
-    try {
-      return jsonEncode({'type': getActionType(action), 'payload': action});
-    } on Error {
-      return jsonEncode({'type': getActionType(action)});
-    }
-  }
-
+ActionEncoder JsonActionEncoder = (dynamic action) {
   /// Gets a type name for the action, based on the class name or value
   String getActionType(dynamic action) {
     if (action.toString().contains('Instance of')) {
@@ -39,4 +13,10 @@ class JsonActionEncoder extends ActionEncoder {
     }
     return action.toString();
   }
-}
+
+  try {
+    return jsonEncode({'type': getActionType(action), 'payload': action});
+  } on Error {
+    return jsonEncode({'type': getActionType(action)});
+  }
+};

--- a/lib/src/state_encoder.dart
+++ b/lib/src/state_encoder.dart
@@ -5,6 +5,4 @@ part of redux_remote_devtools;
 typedef StateEncoder<State> = String Function(State state);
 
 /// A State encoder that converts a state instances to stringified JSON
-StateEncoder<dynamic> JsonStateEncoder = (dynamic state) {
-  jsonEncode(state);
-};
+StateEncoder<dynamic> JsonStateEncoder = (dynamic state) => jsonEncode(state);

--- a/lib/src/state_encoder.dart
+++ b/lib/src/state_encoder.dart
@@ -1,20 +1,10 @@
 part of redux_remote_devtools;
 
 /// Interface for custom State encoding logic
-abstract class StateEncoder {
-  const StateEncoder();
-
-  // Converts a State instance into a string suitable for sending to devtools
-  String encode(dynamic state);
-}
+/// Converts a State instance into a string suitable for sending to devtools
+typedef StateEncoder<State> = String Function(State state);
 
 /// A State encoder that converts a state instances to stringified JSON
-class JsonStateEncoder extends StateEncoder {
-  const JsonStateEncoder() : super();
-
-  /// Encodes a state instance as stringified JSON
-  @override
-  String encode(dynamic state) {
-    return jsonEncode(state);
-  }
-}
+StateEncoder<dynamic> JsonStateEncoder = (dynamic state) {
+  jsonEncode(state);
+};

--- a/test/action_decoder_test.dart
+++ b/test/action_decoder_test.dart
@@ -6,8 +6,8 @@ void main() {
     group('decode', () {
       test('Passes through the json payload', () {
         var payload = {'type': 'SOME ACTION', 'value': 123};
-        var decoder = NopActionDecoder();
-        var result = decoder.decode(payload);
+        var decoder = NopActionDecoder;
+        var result = decoder(payload);
         expect(result, payload);
       });
     });

--- a/test/action_encoder_test.dart
+++ b/test/action_encoder_test.dart
@@ -16,16 +16,16 @@ void main() {
   group('JsonActionEncoder', () {
     group('encodeAction', () {
       test('Returns a jsonified action', () {
-        var encoder = JsonActionEncoder();
-        var result = encoder.encode(TestAction(value: 5));
+        var encoder = JsonActionEncoder;
+        var result = encoder(TestAction(value: 5));
         var decoded = jsonDecode(result);
         expect(decoded['type'], equals('TestAction'));
         expect(decoded['payload']['value'], equals(5));
       });
 
       test('Still returns the type if action is not jsonable', () {
-        var encoder = JsonActionEncoder();
-        var result = encoder.encode(EnumActions.SimpleEnumAction);
+        var encoder = JsonActionEncoder;
+        var result = encoder(EnumActions.SimpleEnumAction);
         var decoded = jsonDecode(result);
         expect(decoded['type'], equals('EnumActions.SimpleEnumAction'));
         expect(decoded['payload'], equals(null));
@@ -34,13 +34,13 @@ void main() {
 
     group('getActionType', () {
       test('Returns the class name for a class based action', () {
-        var encoder = JsonActionEncoder();
-        var result = encoder.getActionType(TestAction());
+        var encoder = JsonActionEncoder;
+        var result = encoder(TestAction());
         expect(result, equals('TestAction'));
       });
       test('Returns the value for enum actions', () {
-        var encoder = JsonActionEncoder();
-        var result = encoder.getActionType(EnumActions.SimpleEnumAction);
+        var encoder = JsonActionEncoder;
+        var result = encoder(EnumActions.SimpleEnumAction);
         expect(result, equals('EnumActions.SimpleEnumAction'));
       });
     });

--- a/test/action_encoder_test.dart
+++ b/test/action_encoder_test.dart
@@ -31,18 +31,5 @@ void main() {
         expect(decoded['payload'], equals(null));
       });
     });
-
-    group('getActionType', () {
-      test('Returns the class name for a class based action', () {
-        var encoder = JsonActionEncoder;
-        var result = encoder(TestAction());
-        expect(result, equals('TestAction'));
-      });
-      test('Returns the value for enum actions', () {
-        var encoder = JsonActionEncoder;
-        var result = encoder(EnumActions.SimpleEnumAction);
-        expect(result, equals('EnumActions.SimpleEnumAction'));
-      });
-    });
   });
 }

--- a/test/state_encoder_test.dart
+++ b/test/state_encoder_test.dart
@@ -21,15 +21,15 @@ void main() {
   group('JsonStateEncoder', () {
     group('encode', () {
       test('Returns a jsonified state', () {
-        var encoder = JsonStateEncoder();
-        var result = encoder.encode(TestState(value: 5));
+        var encoder = JsonStateEncoder;
+        var result = encoder(TestState(value: 5));
         var decoded = jsonDecode(result);
         expect(decoded['value'], equals(5));
       });
       test('Throws an exception if unencodable', () {
-        var encoder = JsonStateEncoder();
+        var encoder = JsonStateEncoder;
         var testFunc = () {
-          encoder.encode(TestUnencodableState(value: 5));
+          encoder(TestUnencodableState(value: 5));
         };
         expect(testFunc, throwsA(TypeMatcher<JsonUnsupportedObjectError>()));
       });


### PR DESCRIPTION
In line with the [Dart Styleguide](http://dart-lang.github.io/linter/lints/one_member_abstracts.html), this PR replaces the `ActionEncoder`, `ActionDecoder`, and `StateEncoder` abstract classes with function typedefs. 

Closes #11