### PR TITLE
Made instance name configurable

### DIFF
--- a/lib/src/remote_devtools_middleware.dart
+++ b/lib/src/remote_devtools_middleware.dart
@@ -41,17 +41,22 @@ class RemoteDevToolsMiddleware<State> extends MiddlewareClass<State> {
   /// The function used to encode state to a String for sending. If not specifies, defaults to [JsonStateEncoder]
   StateEncoder<State> stateEncoder;
 
+  /// The name that will appear in Instance Name in Dev Tools. If not specified, default to 'flutter'.
+  String instanceName;
+
   RemoteDevToolsMiddleware(
     this._host, {
     this.actionDecoder,
     this.actionEncoder,
     this.stateEncoder,
     this.socket,
+    this.instanceName,
   }) {
     actionEncoder ??= JsonActionEncoder;
     actionDecoder ??= NopActionDecoder;
     stateEncoder ??= JsonStateEncoder;
     socket ??= SocketClusterWrapper('ws://$_host/socketcluster/');
+    instanceName ??= 'flutter';
   }
 
   Future<void> connect() async {
@@ -93,7 +98,7 @@ class RemoteDevToolsMiddleware<State> extends MiddlewareClass<State> {
 
   void _relay(String type,
       [Object state, dynamic action, String nextActionId]) {
-    var message = {'type': type, 'id': socket.id, 'name': 'flutter'};
+    var message = {'type': type, 'id': socket.id, 'name': instanceName};
 
     if (state != null) {
       try {

--- a/test/remote_devtools_middleware_test.dart
+++ b/test/remote_devtools_middleware_test.dart
@@ -68,6 +68,23 @@ void main() {
         verify(socket.emit('log',
             {'type': 'START', 'id': 'testId', 'name': 'flutter'}, captureAny));
       });
+      test('instance name is configurable', () async {
+        final coolInstanceName = 'testName';
+        devtools = RemoteDevToolsMiddleware('example.com', socket: socket, instanceName: coolInstanceName);
+        when(socket.emit('login', 'master', captureAny))
+            .thenAnswer((Invocation i) {
+          Function fn = i.positionalArguments[2];
+          fn('testChannel', 'err', 'data');
+        });
+        when(socket.id).thenReturn('testId');
+        when(socket.on('data', captureAny)).thenAnswer((Invocation i) {
+          Function fn = i.positionalArguments[1];
+          fn('name', {'type': 'START'});
+        });
+        await devtools.connect();
+        verify(socket.emit('log',
+            {'type': 'START', 'id': 'testId', 'name': '$coolInstanceName'}, captureAny));
+      });
       test('it is in STARTED state', () async {
         when(socket.connect()).thenAnswer((_) => Future.value());
         when(socket.id).thenReturn('testId');


### PR DESCRIPTION
Instance name is currently hardcoded to `flutter`. When debugging multiple apps simultaneously, it's hard to distinguish which state belong to which app. I made instance name configurable via the middleware as an optional argument to the constructor. The default remains `flutter`.